### PR TITLE
Persist listen/write tutorial completion and patch vulnerable packages

### DIFF
--- a/src/host/WriteFluency.ServiceDefaults/WriteFluency.ServiceDefaults.csproj
+++ b/src/host/WriteFluency.ServiceDefaults/WriteFluency.ServiceDefaults.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.4.0" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.3.0" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.3.0" />
+    <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.0" />

--- a/src/propositions-service/WriteFluency.Infrastructure/WriteFluency.Infrastructure.csproj
+++ b/src/propositions-service/WriteFluency.Infrastructure/WriteFluency.Infrastructure.csproj
@@ -13,12 +13,12 @@
     </PackageReference>
     <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="13.1.2" />
     <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="9.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.3.1" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.3" />
     <PackageReference Include="Microsoft.CognitiveServices.Speech" Version="1.47.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.AI" Version="9.6.0" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="9.6.0-preview.1.25310.2" />
+    <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
     <PackageReference Include="CommunityToolkit.Aspire.Minio.Client" Version="9.5.1-beta.308" />
   </ItemGroup>
   <ItemGroup>

--- a/src/users-service/WriteFluency.Users.WebApi/Authentication/AuthEndpointExtensions.cs
+++ b/src/users-service/WriteFluency.Users.WebApi/Authentication/AuthEndpointExtensions.cs
@@ -3,6 +3,7 @@ using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Google;
 using Microsoft.AspNetCore.Authentication.MicrosoftAccount;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.WebUtilities;
@@ -32,6 +33,9 @@ public static class AuthEndpointExtensions
             .RequireAuthorization();
 
         authGroup.MapGet("/session", GetSession)
+            .RequireAuthorization();
+
+        authGroup.MapPost("/tutorial/listen-write/completed", MarkListenWriteTutorialCompletedAsync)
             .RequireAuthorization();
 
         authGroup.MapPost("/passwordless/request", RequestPasswordlessOtpAsync);
@@ -80,8 +84,37 @@ public static class AuthEndpointExtensions
             UserId = user?.Id ?? principal.FindFirstValue(ClaimTypes.NameIdentifier),
             Email = user?.Email ?? principal.FindFirstValue(ClaimTypes.Email),
             EmailConfirmed = user?.EmailConfirmed ?? false,
+            ListenWriteTutorialCompleted = user?.ListenWriteTutorialCompleted ?? false,
             IssuedAtUtc = issuedAtUtc,
             ExpiresAtUtc = expiresAtUtc
+        });
+    }
+
+    private static async Task<IResult> MarkListenWriteTutorialCompletedAsync(
+        ClaimsPrincipal principal,
+        UserManager<ApplicationUser> userManager)
+    {
+        var user = await userManager.GetUserAsync(principal);
+        if (user is null)
+        {
+            return Results.Unauthorized();
+        }
+
+        if (!user.ListenWriteTutorialCompleted)
+        {
+            user.ListenWriteTutorialCompleted = true;
+            var updateResult = await userManager.UpdateAsync(user);
+            if (!updateResult.Succeeded)
+            {
+                return Results.Problem(
+                    detail: "Unable to persist tutorial completion.",
+                    statusCode: StatusCodes.Status500InternalServerError);
+            }
+        }
+
+        return Results.Ok(new
+        {
+            ListenWriteTutorialCompleted = true
         });
     }
 

--- a/src/users-service/WriteFluency.Users.WebApi/Data/ApplicationUser.cs
+++ b/src/users-service/WriteFluency.Users.WebApi/Data/ApplicationUser.cs
@@ -4,4 +4,5 @@ namespace WriteFluency.Users.WebApi.Data;
 
 public class ApplicationUser : IdentityUser
 {
+    public bool ListenWriteTutorialCompleted { get; set; }
 }

--- a/src/users-service/WriteFluency.Users.WebApi/Data/Migrations/20260424134253_AddListenWriteTutorialCompleted.Designer.cs
+++ b/src/users-service/WriteFluency.Users.WebApi/Data/Migrations/20260424134253_AddListenWriteTutorialCompleted.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using WriteFluency.Users.WebApi.Data;
@@ -11,9 +12,11 @@ using WriteFluency.Users.WebApi.Data;
 namespace WriteFluency.Users.WebApi.Data.Migrations
 {
     [DbContext(typeof(UsersDbContext))]
-    partial class UsersDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260424134253_AddListenWriteTutorialCompleted")]
+    partial class AddListenWriteTutorialCompleted
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/users-service/WriteFluency.Users.WebApi/Data/Migrations/20260424134253_AddListenWriteTutorialCompleted.cs
+++ b/src/users-service/WriteFluency.Users.WebApi/Data/Migrations/20260424134253_AddListenWriteTutorialCompleted.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace WriteFluency.Users.WebApi.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddListenWriteTutorialCompleted : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "ListenWriteTutorialCompleted",
+                table: "AspNetUsers",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ListenWriteTutorialCompleted",
+                table: "AspNetUsers");
+        }
+    }
+}

--- a/src/webapp/src/app/auth/models/auth-session.model.ts
+++ b/src/webapp/src/app/auth/models/auth-session.model.ts
@@ -3,6 +3,7 @@ export interface AuthSession {
   userId: string | null;
   email: string | null;
   emailConfirmed: boolean;
+  listenWriteTutorialCompleted?: boolean;
   issuedAtUtc: string | null;
   expiresAtUtc: string | null;
 }
@@ -12,6 +13,8 @@ export interface AuthSessionState {
   userId: string | null;
   email: string | null;
   emailConfirmed: boolean;
+  listenWriteTutorialCompleted: boolean | null;
+  hasReliableSessionState: boolean;
   issuedAtUtc: string | null;
   expiresAtUtc: string | null;
   isLoading: boolean;

--- a/src/webapp/src/app/auth/services/auth-api.service.spec.ts
+++ b/src/webapp/src/app/auth/services/auth-api.service.spec.ts
@@ -44,4 +44,13 @@ describe('AuthApiService', () => {
     expect(request.request.withCredentials).toBeTrue();
     request.flush([]);
   });
+
+  it('should call tutorial mark-completed endpoint', () => {
+    service.markListenWriteTutorialCompleted().subscribe();
+
+    const request = httpMock.expectOne(`${authBaseUrl}/tutorial/listen-write/completed`);
+    expect(request.request.method).toBe('POST');
+    expect(request.request.withCredentials).toBeTrue();
+    request.flush({ listenWriteTutorialCompleted: true });
+  });
 });

--- a/src/webapp/src/app/auth/services/auth-api.service.ts
+++ b/src/webapp/src/app/auth/services/auth-api.service.ts
@@ -28,6 +28,14 @@ export class AuthApiService {
     return this.http.get<AuthSession>(`${this.basePath}/session`, { withCredentials: true });
   }
 
+  markListenWriteTutorialCompleted(): Observable<{ listenWriteTutorialCompleted: true }> {
+    return this.http.post<{ listenWriteTutorialCompleted: true }>(
+      `${this.basePath}/tutorial/listen-write/completed`,
+      {},
+      { withCredentials: true },
+    );
+  }
+
   requestOtp(email: string): Observable<{ message: string }> {
     return this.http.post<{ message: string }>(`${this.basePath}/passwordless/request`, { email }, { withCredentials: true });
   }

--- a/src/webapp/src/app/auth/services/auth-session.store.spec.ts
+++ b/src/webapp/src/app/auth/services/auth-session.store.spec.ts
@@ -11,7 +11,11 @@ describe('AuthSessionStore', () => {
   beforeEach(() => {
     window.localStorage.removeItem('wf.auth.session.snapshot.v1');
 
-    authApiServiceSpy = jasmine.createSpyObj<AuthApiService>('AuthApiService', ['session', 'logout']);
+    authApiServiceSpy = jasmine.createSpyObj<AuthApiService>('AuthApiService', [
+      'session',
+      'logout',
+      'markListenWriteTutorialCompleted',
+    ]);
 
     TestBed.configureTestingModule({
       providers: [
@@ -38,6 +42,7 @@ describe('AuthSessionStore', () => {
         userId: 'abc',
         email: 'user@test.com',
         emailConfirmed: true,
+        listenWriteTutorialCompleted: false,
         issuedAtUtc,
         expiresAtUtc,
       }),
@@ -46,7 +51,9 @@ describe('AuthSessionStore', () => {
     await store.refreshSession();
 
     expect(store.state().isAuthenticated).toBeTrue();
+    expect(store.state().hasReliableSessionState).toBeTrue();
     expect(store.state().email).toBe('user@test.com');
+    expect(store.state().listenWriteTutorialCompleted).toBeFalse();
     expect(store.state().issuedAtUtc).toBe(issuedAtUtc);
     expect(store.state().expiresAtUtc).toBe(expiresAtUtc);
   });
@@ -58,6 +65,7 @@ describe('AuthSessionStore', () => {
         userId: 'abc',
         email: 'user@test.com',
         emailConfirmed: true,
+        listenWriteTutorialCompleted: false,
         issuedAtUtc: new Date('2026-01-01T00:00:00.000Z').toISOString(),
         expiresAtUtc: new Date('2026-01-01T01:00:00.000Z').toISOString(),
       }),
@@ -70,6 +78,29 @@ describe('AuthSessionStore', () => {
 
     expect(store.state().isAuthenticated).toBeFalse();
     expect(store.state().email).toBeNull();
+    expect(store.state().hasReliableSessionState).toBeTrue();
+    expect(store.state().listenWriteTutorialCompleted).toBeNull();
+  });
+
+  it('should mark session state as unreliable on non-auth refresh failure', async () => {
+    authApiServiceSpy.session.and.returnValues(
+      of({
+        isAuthenticated: true,
+        userId: 'abc',
+        email: 'user@test.com',
+        emailConfirmed: true,
+        listenWriteTutorialCompleted: false,
+        issuedAtUtc: new Date('2026-01-01T00:00:00.000Z').toISOString(),
+        expiresAtUtc: new Date('2026-01-01T01:00:00.000Z').toISOString(),
+      }),
+      throwError(() => ({ status: 0 })),
+    );
+
+    await store.refreshSession();
+    await store.refreshSession();
+
+    expect(store.state().isAuthenticated).toBeTrue();
+    expect(store.state().hasReliableSessionState).toBeFalse();
   });
 
   it('should clear session on logout', async () => {
@@ -91,6 +122,7 @@ describe('AuthSessionStore', () => {
         userId: 'snapshot-user',
         email: 'snapshot@test.com',
         emailConfirmed: true,
+        listenWriteTutorialCompleted: true,
         issuedAtUtc,
         expiresAtUtc,
         cachedAtUtc: new Date('2026-01-01T00:10:00.000Z').toISOString(),
@@ -102,8 +134,28 @@ describe('AuthSessionStore', () => {
     expect(store.state().isAuthenticated).toBeTrue();
     expect(store.state().userId).toBe('snapshot-user');
     expect(store.state().email).toBe('snapshot@test.com');
+    expect(store.state().listenWriteTutorialCompleted).toBeTrue();
+    expect(store.state().hasReliableSessionState).toBeFalse();
     expect(store.state().issuedAtUtc).toBe(issuedAtUtc);
     expect(store.state().expiresAtUtc).toBe(expiresAtUtc);
+  });
+
+  it('should tolerate missing tutorial flag from older session responses', async () => {
+    authApiServiceSpy.session.and.returnValue(
+      of({
+        isAuthenticated: true,
+        userId: 'abc',
+        email: 'user@test.com',
+        emailConfirmed: true,
+        issuedAtUtc: new Date('2026-01-01T00:00:00.000Z').toISOString(),
+        expiresAtUtc: new Date('2026-01-01T01:00:00.000Z').toISOString(),
+      }),
+    );
+
+    await store.refreshSession();
+
+    expect(store.state().listenWriteTutorialCompleted).toBeNull();
+    expect(store.state().hasReliableSessionState).toBeTrue();
   });
 
   it('should trigger background refresh shortly before session expiry', async () => {
@@ -118,6 +170,7 @@ describe('AuthSessionStore', () => {
           userId: 'abc',
           email: 'user@test.com',
           emailConfirmed: true,
+          listenWriteTutorialCompleted: false,
           issuedAtUtc: now.toISOString(),
           expiresAtUtc: new Date(now.getTime() + 6 * 60 * 1000).toISOString(),
         }),
@@ -126,6 +179,7 @@ describe('AuthSessionStore', () => {
           userId: 'abc',
           email: 'user@test.com',
           emailConfirmed: true,
+          listenWriteTutorialCompleted: false,
           issuedAtUtc: now.toISOString(),
           expiresAtUtc: new Date(now.getTime() + 30 * 60 * 1000).toISOString(),
         }),
@@ -150,6 +204,7 @@ describe('AuthSessionStore', () => {
       userId: string;
       email: string;
       emailConfirmed: boolean;
+      listenWriteTutorialCompleted?: boolean;
       issuedAtUtc: string;
       expiresAtUtc: string;
     }>();
@@ -158,6 +213,7 @@ describe('AuthSessionStore', () => {
       userId: string;
       email: string;
       emailConfirmed: boolean;
+      listenWriteTutorialCompleted?: boolean;
       issuedAtUtc: string;
       expiresAtUtc: string;
     }>();
@@ -175,6 +231,7 @@ describe('AuthSessionStore', () => {
       userId: 'new-user',
       email: 'new@test.com',
       emailConfirmed: true,
+      listenWriteTutorialCompleted: true,
       issuedAtUtc: new Date('2026-01-01T02:00:00.000Z').toISOString(),
       expiresAtUtc: new Date('2026-01-01T03:00:00.000Z').toISOString(),
     });
@@ -187,6 +244,7 @@ describe('AuthSessionStore', () => {
       userId: 'old-user',
       email: 'old@test.com',
       emailConfirmed: true,
+      listenWriteTutorialCompleted: false,
       issuedAtUtc: new Date('2026-01-01T00:00:00.000Z').toISOString(),
       expiresAtUtc: new Date('2026-01-01T01:00:00.000Z').toISOString(),
     });
@@ -200,5 +258,53 @@ describe('AuthSessionStore', () => {
     const snapshot = JSON.parse(snapshotRaw as string) as { userId?: string; email?: string };
     expect(snapshot.userId).toBe('new-user');
     expect(snapshot.email).toBe('new@test.com');
+  });
+
+  it('should patch tutorial flag locally after background mark-completed succeeds', async () => {
+    authApiServiceSpy.session.and.returnValue(
+      of({
+        isAuthenticated: true,
+        userId: 'abc',
+        email: 'user@test.com',
+        emailConfirmed: true,
+        listenWriteTutorialCompleted: false,
+        issuedAtUtc: new Date('2026-01-01T00:00:00.000Z').toISOString(),
+        expiresAtUtc: new Date('2026-01-01T01:00:00.000Z').toISOString(),
+      }),
+    );
+    authApiServiceSpy.markListenWriteTutorialCompleted.and.returnValue(
+      of({ listenWriteTutorialCompleted: true }),
+    );
+
+    await store.refreshSession();
+    store.markListenWriteTutorialCompletedInBackground();
+    await Promise.resolve();
+
+    expect(authApiServiceSpy.markListenWriteTutorialCompleted).toHaveBeenCalledTimes(1);
+    expect(store.state().listenWriteTutorialCompleted).toBeTrue();
+  });
+
+  it('should swallow failures from background mark-completed calls', async () => {
+    authApiServiceSpy.session.and.returnValue(
+      of({
+        isAuthenticated: true,
+        userId: 'abc',
+        email: 'user@test.com',
+        emailConfirmed: true,
+        listenWriteTutorialCompleted: false,
+        issuedAtUtc: new Date('2026-01-01T00:00:00.000Z').toISOString(),
+        expiresAtUtc: new Date('2026-01-01T01:00:00.000Z').toISOString(),
+      }),
+    );
+    authApiServiceSpy.markListenWriteTutorialCompleted.and.returnValue(
+      throwError(() => ({ status: 500 })),
+    );
+
+    await store.refreshSession();
+    expect(() => store.markListenWriteTutorialCompletedInBackground()).not.toThrow();
+    await Promise.resolve();
+
+    expect(authApiServiceSpy.markListenWriteTutorialCompleted).toHaveBeenCalledTimes(1);
+    expect(store.state().listenWriteTutorialCompleted).toBeFalse();
   });
 });

--- a/src/webapp/src/app/auth/services/auth-session.store.ts
+++ b/src/webapp/src/app/auth/services/auth-session.store.ts
@@ -15,6 +15,8 @@ const initialState: AuthSessionState = {
   userId: null,
   email: null,
   emailConfirmed: false,
+  listenWriteTutorialCompleted: null,
+  hasReliableSessionState: false,
   issuedAtUtc: null,
   expiresAtUtc: null,
   isLoading: false,
@@ -23,7 +25,13 @@ const initialState: AuthSessionState = {
 
 type AuthSessionSnapshot = Pick<
   AuthSessionState,
-  'isAuthenticated' | 'userId' | 'email' | 'emailConfirmed' | 'issuedAtUtc' | 'expiresAtUtc'
+  | 'isAuthenticated'
+  | 'userId'
+  | 'email'
+  | 'emailConfirmed'
+  | 'listenWriteTutorialCompleted'
+  | 'issuedAtUtc'
+  | 'expiresAtUtc'
 > & {
   cachedAtUtc: string;
 };
@@ -40,10 +48,14 @@ export class AuthSessionStore {
   private hasRegisteredLifecycleListeners = false;
   private refreshRequestCounter = 0;
   private logoutRequestInFlight = false;
+  private markTutorialRequestInFlight = false;
 
   readonly state = this.stateSignal.asReadonly();
   readonly isAuthenticated = computed(() => this.stateSignal().isAuthenticated);
   readonly email = computed(() => this.stateSignal().email);
+  readonly userId = computed(() => this.stateSignal().userId);
+  readonly hasReliableSessionState = computed(() => this.stateSignal().hasReliableSessionState);
+  readonly listenWriteTutorialCompleted = computed(() => this.stateSignal().listenWriteTutorialCompleted);
 
   isLogoutInProgress(): boolean {
     return this.logoutRequestInFlight;
@@ -97,6 +109,30 @@ export class AuthSessionStore {
     this.clearSession();
   }
 
+  markListenWriteTutorialCompletedInBackground(): void {
+    if (!this.isBrowser || this.markTutorialRequestInFlight) {
+      return;
+    }
+
+    const state = this.stateSignal();
+    if (!state.hasReliableSessionState || !state.isAuthenticated || state.listenWriteTutorialCompleted === true) {
+      return;
+    }
+
+    this.markTutorialRequestInFlight = true;
+    void firstValueFrom(this.authApiService.markListenWriteTutorialCompleted())
+      .then(() => {
+        this.patchState({ listenWriteTutorialCompleted: true });
+        this.persistSnapshot();
+      })
+      .catch(() => {
+        // Intentionally swallowed to avoid blocking user flow.
+      })
+      .finally(() => {
+        this.markTutorialRequestInFlight = false;
+      });
+  }
+
   private async refreshSessionCore(options: { showLoading: boolean; persistErrors: boolean }): Promise<void> {
     const requestId = ++this.refreshRequestCounter;
 
@@ -117,6 +153,8 @@ export class AuthSessionStore {
         userId: session.userId,
         email: session.email,
         emailConfirmed: session.emailConfirmed,
+        listenWriteTutorialCompleted: this.resolveTutorialCompletionFlag(session.listenWriteTutorialCompleted),
+        hasReliableSessionState: true,
         issuedAtUtc: session.issuedAtUtc,
         expiresAtUtc: session.expiresAtUtc,
         isLoading: false,
@@ -140,11 +178,15 @@ export class AuthSessionStore {
 
       if (options.persistErrors) {
         this.patchState({
+          hasReliableSessionState: false,
           isLoading: false,
           error: 'Unable to load session right now. Please try again.',
         });
       } else {
-        this.patchState({ isLoading: false });
+        this.patchState({
+          hasReliableSessionState: false,
+          isLoading: false,
+        });
       }
     }
   }
@@ -174,6 +216,8 @@ export class AuthSessionStore {
         userId: snapshot.userId ?? null,
         email: snapshot.email ?? null,
         emailConfirmed: snapshot.emailConfirmed === true,
+        listenWriteTutorialCompleted: this.resolveTutorialCompletionFlag(snapshot.listenWriteTutorialCompleted),
+        hasReliableSessionState: false,
         issuedAtUtc: snapshot.issuedAtUtc ?? null,
         expiresAtUtc: snapshot.expiresAtUtc ?? null,
         isLoading: false,
@@ -197,6 +241,7 @@ export class AuthSessionStore {
       userId: state.userId,
       email: state.email,
       emailConfirmed: state.emailConfirmed,
+      listenWriteTutorialCompleted: state.listenWriteTutorialCompleted,
       issuedAtUtc: state.issuedAtUtc,
       expiresAtUtc: state.expiresAtUtc,
       cachedAtUtc: new Date().toISOString(),
@@ -283,12 +328,18 @@ export class AuthSessionStore {
       userId: null,
       email: null,
       emailConfirmed: false,
+      listenWriteTutorialCompleted: null,
+      hasReliableSessionState: true,
       issuedAtUtc: null,
       expiresAtUtc: null,
       isLoading: false,
       error: null,
     });
     this.persistSnapshot();
+  }
+
+  private resolveTutorialCompletionFlag(value: unknown): boolean | null {
+    return typeof value === 'boolean' ? value : null;
   }
 
   private patchState(patch: Partial<AuthSessionState>): void {

--- a/src/webapp/src/app/listen-and-write/listen-and-write.component.spec.ts
+++ b/src/webapp/src/app/listen-and-write/listen-and-write.component.spec.ts
@@ -6,6 +6,7 @@ import { Subject } from 'rxjs';
 import { ListenAndWriteComponent, LISTEN_WRITE_FIRST_TIME_KEY } from './listen-and-write.component';
 import { ExerciseProgressTrackingService } from './services/exercise-progress-tracking.service';
 import { AuthSessionStore } from '../auth/services/auth-session.store';
+import { Insights } from '../../telemetry/insights.service';
 
 const guestBeginAttemptCountStorageKey = 'wf.guest.begin.exercise.attempt.v1';
 const guestBeginLoginModalLastShownStorageKey = 'wf.guest.login.modal.last-shown-utc.v1';
@@ -16,6 +17,7 @@ describe('ListenAndWriteComponent', () => {
   let routeParams$: Subject<Record<string, unknown>>;
   let progressSyncNotificationSignal: ReturnType<typeof signal>;
   let authSessionStoreMock: jasmine.SpyObj<AuthSessionStore>;
+  let insightsMock: jasmine.SpyObj<Insights>;
   let exerciseProgressTrackingMock: {
     trackStart: jasmine.Spy;
     trackComplete: jasmine.Spy;
@@ -32,11 +34,21 @@ describe('ListenAndWriteComponent', () => {
 
     routeParams$ = new Subject<Record<string, unknown>>();
     progressSyncNotificationSignal = signal<any>(null);
+    insightsMock = jasmine.createSpyObj<Insights>('Insights', ['trackException', 'trackEvent']);
     authSessionStoreMock = jasmine.createSpyObj<AuthSessionStore>(
       'AuthSessionStore',
-      ['isAuthenticated'],
+      [
+        'isAuthenticated',
+        'hasReliableSessionState',
+        'listenWriteTutorialCompleted',
+        'userId',
+        'markListenWriteTutorialCompletedInBackground',
+      ],
     );
     authSessionStoreMock.isAuthenticated.and.returnValue(false);
+    authSessionStoreMock.hasReliableSessionState.and.returnValue(true);
+    authSessionStoreMock.listenWriteTutorialCompleted.and.returnValue(null);
+    authSessionStoreMock.userId.and.returnValue(null);
     exerciseProgressTrackingMock = {
       trackStart: jasmine.createSpy('trackStart'),
       trackComplete: jasmine.createSpy('trackComplete'),
@@ -63,7 +75,11 @@ describe('ListenAndWriteComponent', () => {
         {
           provide: AuthSessionStore,
           useValue: authSessionStoreMock,
-        }
+        },
+        {
+          provide: Insights,
+          useValue: insightsMock,
+        },
       ]
     })
     .compileComponents();
@@ -75,6 +91,56 @@ describe('ListenAndWriteComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should treat tutorial as first-time when local key is missing and session is reliably unauthenticated', () => {
+    authSessionStoreMock.isAuthenticated.and.returnValue(false);
+    authSessionStoreMock.hasReliableSessionState.and.returnValue(true);
+    authSessionStoreMock.listenWriteTutorialCompleted.and.returnValue(null);
+    window.localStorage.removeItem(LISTEN_WRITE_FIRST_TIME_KEY);
+
+    expect(component.isFirstTime()).toBeTrue();
+  });
+
+  it('should not treat tutorial as first-time when authenticated user already completed on server', () => {
+    authSessionStoreMock.isAuthenticated.and.returnValue(true);
+    authSessionStoreMock.hasReliableSessionState.and.returnValue(true);
+    authSessionStoreMock.listenWriteTutorialCompleted.and.returnValue(true);
+    window.localStorage.removeItem(LISTEN_WRITE_FIRST_TIME_KEY);
+
+    expect(component.isFirstTime()).toBeFalse();
+  });
+
+  it('should treat tutorial as first-time when authenticated user has not completed on server', () => {
+    authSessionStoreMock.isAuthenticated.and.returnValue(true);
+    authSessionStoreMock.hasReliableSessionState.and.returnValue(true);
+    authSessionStoreMock.listenWriteTutorialCompleted.and.returnValue(false);
+    window.localStorage.removeItem(LISTEN_WRITE_FIRST_TIME_KEY);
+
+    expect(component.isFirstTime()).toBeTrue();
+  });
+
+  it('should suppress tutorial and log one Insights exception when session reliability is unknown', () => {
+    authSessionStoreMock.isAuthenticated.and.returnValue(false);
+    authSessionStoreMock.hasReliableSessionState.and.returnValue(false);
+    authSessionStoreMock.listenWriteTutorialCompleted.and.returnValue(null);
+    window.localStorage.removeItem(LISTEN_WRITE_FIRST_TIME_KEY);
+
+    expect(component.isFirstTime()).toBeFalse();
+    expect(component.isFirstTime()).toBeFalse();
+    expect(insightsMock.trackException).toHaveBeenCalledTimes(1);
+  });
+
+  it('should backfill tutorial completion once per authenticated user when local key is already done', () => {
+    authSessionStoreMock.isAuthenticated.and.returnValue(true);
+    authSessionStoreMock.hasReliableSessionState.and.returnValue(true);
+    authSessionStoreMock.listenWriteTutorialCompleted.and.returnValue(null);
+    authSessionStoreMock.userId.and.returnValue('user-123');
+    window.localStorage.setItem(LISTEN_WRITE_FIRST_TIME_KEY, 'false');
+
+    expect(component.isFirstTime()).toBeFalse();
+    expect(component.isFirstTime()).toBeFalse();
+    expect(authSessionStoreMock.markListenWriteTutorialCompletedInBackground).toHaveBeenCalledTimes(1);
   });
 
   it('should use auto-pause value for rewind shortcut when enabled', () => {

--- a/src/webapp/src/app/listen-and-write/listen-and-write.component.ts
+++ b/src/webapp/src/app/listen-and-write/listen-and-write.component.ts
@@ -1,4 +1,4 @@
-import { Component, signal, ViewChild, HostListener, effect, OnDestroy, afterNextRender } from '@angular/core';
+import { Component, signal, ViewChild, HostListener, effect, OnDestroy, Optional, afterNextRender } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 import { NewsInfoComponent } from './news-info/news-info.component';
@@ -22,6 +22,7 @@ import { FeedbackService, ExerciseFeedbackEvent } from './services/feedback.serv
 import { ExerciseProgressTrackingService, ProgressSyncNotification } from './services/exercise-progress-tracking.service';
 import { AuthSessionStore } from '../auth/services/auth-session.store';
 import { ProgressStateResponse } from '../user/models/user-progress.model';
+import { Insights } from '../../telemetry/insights.service';
 import {
   FeedbackModalComponent,
   FeedbackModalInteractionEvent,
@@ -133,6 +134,8 @@ export class ListenAndWriteComponent implements OnDestroy {
   private hasTrackedResultsLoginCtaView = false;
   private exerciseStartedAtMs: number | null = null;
   private shouldSyncCompletedResultAfterRestore = false;
+  private hasLoggedTutorialSuppressedException = false;
+  private readonly tutorialBackfillRequestedUsers = new Set<string>();
 
   constructor(
     private listenFirstTourService: ListenFirstTourService,
@@ -148,6 +151,7 @@ export class ListenAndWriteComponent implements OnDestroy {
     private feedbackService: FeedbackService,
     private exerciseProgressTracking: ExerciseProgressTrackingService,
     private authSessionStore: AuthSessionStore,
+    @Optional() private readonly insights: Insights | null = null,
   ) {
     let lastState: ExerciseState | null = null;
     // Get the exercise ID from route parameters
@@ -1399,12 +1403,73 @@ export class ListenAndWriteComponent implements OnDestroy {
     }
   }
 
-  isFirstTime() : boolean {
-    const firstTime = this.browserService.getItem(LISTEN_WRITE_FIRST_TIME_KEY);
-    if (firstTime === null) {
+  isFirstTime(): boolean {
+    const localTutorialKey = this.browserService.getItem(LISTEN_WRITE_FIRST_TIME_KEY);
+    const hasLocalDone = localTutorialKey !== null;
+    const isAuthenticated = this.authSessionStore.isAuthenticated();
+    const hasReliableSessionState = this.authSessionStore.hasReliableSessionState();
+    const serverTutorialCompleted = this.authSessionStore.listenWriteTutorialCompleted();
+    const userId = this.authSessionStore.userId();
+
+    if (hasLocalDone) {
+      this.tryBackfillTutorialCompletionIfNeeded(
+        isAuthenticated,
+        hasReliableSessionState,
+        serverTutorialCompleted,
+        userId,
+      );
+      return false;
+    }
+
+    if (!hasReliableSessionState) {
+      this.trackTutorialSuppressedForUnreliableSessionState(isAuthenticated);
+      return false;
+    }
+
+    if (!isAuthenticated) {
       return true;
     }
-    return false;
+
+    return serverTutorialCompleted !== true;
+  }
+
+  private tryBackfillTutorialCompletionIfNeeded(
+    isAuthenticated: boolean,
+    hasReliableSessionState: boolean,
+    serverTutorialCompleted: boolean | null,
+    userId: string | null,
+  ): void {
+    if (!isAuthenticated || !hasReliableSessionState || serverTutorialCompleted === true) {
+      return;
+    }
+
+    const backfillKey = userId ?? '__authenticated_unknown_user__';
+    if (this.tutorialBackfillRequestedUsers.has(backfillKey)) {
+      return;
+    }
+
+    this.tutorialBackfillRequestedUsers.add(backfillKey);
+    this.authSessionStore.markListenWriteTutorialCompletedInBackground();
+  }
+
+  private trackTutorialSuppressedForUnreliableSessionState(isAuthenticated: boolean): void {
+    if (this.hasLoggedTutorialSuppressedException) {
+      return;
+    }
+
+    this.hasLoggedTutorialSuppressedException = true;
+    this.insights?.trackException(
+      new Error('Tutorial suppressed because auth session state is unresolved.'),
+      {
+        properties: {
+          component: 'ListenAndWriteComponent',
+          tutorial_key_present: 'false',
+          has_reliable_session_state: 'false',
+          is_authenticated: String(isAuthenticated),
+        },
+        severityLevel: 1,
+      },
+    );
   }
 
   private isMobileLayout(): boolean {

--- a/src/webapp/src/app/listen-and-write/services/exercise-tour.service.spec.ts
+++ b/src/webapp/src/app/listen-and-write/services/exercise-tour.service.spec.ts
@@ -1,0 +1,86 @@
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ShepherdService } from 'angular-shepherd';
+import { BrowserService } from '../../core/services/browser.service';
+import { AuthSessionStore } from '../../auth/services/auth-session.store';
+import { LISTEN_WRITE_FIRST_TIME_KEY } from '../listen-and-write.component';
+import { ExerciseSessionTrackingService } from './exercise-session-tracking.service';
+import { ExerciseTourService } from './exercise-tour.service';
+
+describe('ExerciseTourService', () => {
+  let service: ExerciseTourService;
+  let shepherdMock: any;
+  let browserServiceMock: jasmine.SpyObj<BrowserService>;
+  let exerciseSessionTrackingMock: jasmine.SpyObj<ExerciseSessionTrackingService>;
+  let authSessionStoreMock: jasmine.SpyObj<AuthSessionStore>;
+  let tourCallbacks: Record<string, () => void>;
+
+  beforeEach(() => {
+    tourCallbacks = {};
+    shepherdMock = {
+      isActive: false,
+      defaultStepOptions: undefined,
+      modal: false,
+      keyboardNavigation: true,
+      complete: jasmine.createSpy('complete'),
+      cancel: jasmine.createSpy('cancel'),
+      next: jasmine.createSpy('next'),
+      back: jasmine.createSpy('back'),
+      addSteps: jasmine.createSpy('addSteps'),
+      start: jasmine.createSpy('start'),
+      tourObject: {
+        on: jasmine.createSpy('on').and.callFake((eventName: string, callback: () => void) => {
+          tourCallbacks[eventName] = callback;
+        }),
+      },
+    };
+
+    browserServiceMock = jasmine.createSpyObj<BrowserService>('BrowserService', ['setItem']);
+    exerciseSessionTrackingMock = jasmine.createSpyObj<ExerciseSessionTrackingService>('ExerciseSessionTrackingService', ['trackEvent']);
+    authSessionStoreMock = jasmine.createSpyObj<AuthSessionStore>('AuthSessionStore', [
+      'markListenWriteTutorialCompletedInBackground',
+    ]);
+
+    TestBed.configureTestingModule({
+      providers: [
+        ExerciseTourService,
+        { provide: ShepherdService, useValue: shepherdMock },
+        { provide: BrowserService, useValue: browserServiceMock },
+        { provide: ExerciseSessionTrackingService, useValue: exerciseSessionTrackingMock },
+        { provide: AuthSessionStore, useValue: authSessionStoreMock },
+      ],
+    });
+
+    service = TestBed.inject(ExerciseTourService);
+  });
+
+  it('should mark tutorial done locally and sync in background when desktop tour completes', fakeAsync(() => {
+    service.startTour();
+    tick(51);
+
+    expect(shepherdMock.start).toHaveBeenCalled();
+    tourCallbacks['complete']?.();
+
+    expect(browserServiceMock.setItem).toHaveBeenCalledWith(LISTEN_WRITE_FIRST_TIME_KEY, 'false');
+    expect(authSessionStoreMock.markListenWriteTutorialCompletedInBackground).toHaveBeenCalled();
+  }));
+
+  it('should mark tutorial done locally and sync in background when desktop tour is cancelled', fakeAsync(() => {
+    service.startTour();
+    tick(51);
+
+    tourCallbacks['cancel']?.();
+
+    expect(browserServiceMock.setItem).toHaveBeenCalledWith(LISTEN_WRITE_FIRST_TIME_KEY, 'false');
+    expect(authSessionStoreMock.markListenWriteTutorialCompletedInBackground).toHaveBeenCalled();
+  }));
+
+  it('should mark tutorial done locally and sync in background when mobile tour is cancelled', fakeAsync(() => {
+    service.startMobileTour();
+    tick(51);
+
+    tourCallbacks['cancel']?.();
+
+    expect(browserServiceMock.setItem).toHaveBeenCalledWith(LISTEN_WRITE_FIRST_TIME_KEY, 'false');
+    expect(authSessionStoreMock.markListenWriteTutorialCompletedInBackground).toHaveBeenCalled();
+  }));
+});

--- a/src/webapp/src/app/listen-and-write/services/exercise-tour.service.ts
+++ b/src/webapp/src/app/listen-and-write/services/exercise-tour.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { offset } from '@floating-ui/dom';
 import { ShepherdService } from 'angular-shepherd';
 import { BrowserService } from '../../core/services/browser.service';
+import { AuthSessionStore } from '../../auth/services/auth-session.store';
 import { LISTEN_WRITE_FIRST_TIME_KEY } from '../listen-and-write.component';
 import { ExerciseSessionTrackingService } from './exercise-session-tracking.service';
 
@@ -12,7 +13,8 @@ export class ExerciseTourService {
   constructor(
     private shepherd: ShepherdService,
     private browserService: BrowserService,
-    private exerciseSessionTracking: ExerciseSessionTrackingService
+    private exerciseSessionTracking: ExerciseSessionTrackingService,
+    private authSessionStore: AuthSessionStore,
   ) { }
 
   finishTour() {
@@ -247,6 +249,7 @@ export class ExerciseTourService {
           outcome: 'complete'
         });
         this.browserService.setItem(LISTEN_WRITE_FIRST_TIME_KEY, 'false');
+        this.authSessionStore.markListenWriteTutorialCompletedInBackground();
       });
       this.shepherd.tourObject?.on('cancel', () => {
         this.exerciseSessionTracking.trackEvent('shepherd_tour_finished', {
@@ -254,6 +257,7 @@ export class ExerciseTourService {
           outcome: 'cancel'
         });
         this.browserService.setItem(LISTEN_WRITE_FIRST_TIME_KEY, 'false');
+        this.authSessionStore.markListenWriteTutorialCompletedInBackground();
       });
 
       this.shepherd.start();
@@ -407,6 +411,7 @@ export class ExerciseTourService {
           outcome: 'complete'
         });
         this.browserService.setItem(LISTEN_WRITE_FIRST_TIME_KEY, 'false');
+        this.authSessionStore.markListenWriteTutorialCompletedInBackground();
       });
       this.shepherd.tourObject?.on('cancel', () => {
         this.exerciseSessionTracking.trackEvent('shepherd_tour_finished', {
@@ -414,6 +419,7 @@ export class ExerciseTourService {
           outcome: 'cancel'
         });
         this.browserService.setItem(LISTEN_WRITE_FIRST_TIME_KEY, 'false');
+        this.authSessionStore.markListenWriteTutorialCompletedInBackground();
       });
 
       this.shepherd.start();

--- a/src/webapp/src/app/shared/navbar/navbar.component.spec.ts
+++ b/src/webapp/src/app/shared/navbar/navbar.component.spec.ts
@@ -24,6 +24,8 @@ describe('NavbarComponent', () => {
       userId: 'user-1',
       email: 'user@test.com',
       emailConfirmed: true,
+      listenWriteTutorialCompleted: true,
+      hasReliableSessionState: true,
       issuedAtUtc: null,
       expiresAtUtc: null,
       isLoading: false,

--- a/src/webapp/src/app/user/user.component.spec.ts
+++ b/src/webapp/src/app/user/user.component.spec.ts
@@ -25,6 +25,8 @@ describe('UserComponent', () => {
         userId: 'user-123',
         email: 'user@test.com',
         emailConfirmed: true,
+        listenWriteTutorialCompleted: true,
+        hasReliableSessionState: true,
         issuedAtUtc: new Date().toISOString(),
         expiresAtUtc: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
         isLoading: false,

--- a/tests/users-service/WriteFluency.Users.IntegrationTests/Authentication/AuthEndpointsIntegrationTests.cs
+++ b/tests/users-service/WriteFluency.Users.IntegrationTests/Authentication/AuthEndpointsIntegrationTests.cs
@@ -115,6 +115,7 @@ public class AuthEndpointsIntegrationTests : IClassFixture<UsersApiIntegrationFi
             sessionDoc.RootElement.GetProperty("isAuthenticated").GetBoolean().ShouldBeTrue();
             sessionDoc.RootElement.GetProperty("emailConfirmed").GetBoolean().ShouldBeTrue();
             sessionDoc.RootElement.GetProperty("email").GetString().ShouldBe(email);
+            sessionDoc.RootElement.GetProperty("listenWriteTutorialCompleted").GetBoolean().ShouldBeFalse();
             sessionDoc.RootElement.TryGetProperty("issuedAtUtc", out var issuedAtUtc).ShouldBeTrue();
             sessionDoc.RootElement.TryGetProperty("expiresAtUtc", out var expiresAtUtc).ShouldBeTrue();
             DateTimeOffset.TryParse(issuedAtUtc.GetString(), out _).ShouldBeTrue();
@@ -181,6 +182,61 @@ public class AuthEndpointsIntegrationTests : IClassFixture<UsersApiIntegrationFi
             expectedProvider: null,
             expectedGeoLookupStatus: "success",
             expectedIpAddress: forwardedClientIp);
+    }
+
+    [Fact]
+    public async Task MarkListenWriteTutorialCompleted_ShouldSetFlagAndBeIdempotent()
+    {
+        if (!CanRunIntegration())
+        {
+            return;
+        }
+
+        await _fixture.ResetAsync();
+        using var client = _fixture.CreateClient();
+
+        var email = $"tutorial-{Guid.NewGuid():N}@writefluency.test";
+        const string password = "Passw0rd!123";
+        await RegisterConfirmAndLoginAsync(client, email, password);
+
+        var firstCall = await PostAsJsonWithAllowedOriginAsync(client, "/users/auth/tutorial/listen-write/completed", new { });
+        firstCall.IsSuccessStatusCode.ShouldBeTrue();
+        using (var firstDoc = await JsonDocument.ParseAsync(await firstCall.Content.ReadAsStreamAsync()))
+        {
+            firstDoc.RootElement.GetProperty("listenWriteTutorialCompleted").GetBoolean().ShouldBeTrue();
+        }
+
+        var secondCall = await PostAsJsonWithAllowedOriginAsync(client, "/users/auth/tutorial/listen-write/completed", new { });
+        secondCall.IsSuccessStatusCode.ShouldBeTrue();
+        using (var secondDoc = await JsonDocument.ParseAsync(await secondCall.Content.ReadAsStreamAsync()))
+        {
+            secondDoc.RootElement.GetProperty("listenWriteTutorialCompleted").GetBoolean().ShouldBeTrue();
+        }
+
+        var session = await client.GetAsync("/users/auth/session");
+        session.IsSuccessStatusCode.ShouldBeTrue();
+        using (var sessionDoc = await JsonDocument.ParseAsync(await session.Content.ReadAsStreamAsync()))
+        {
+            sessionDoc.RootElement.GetProperty("listenWriteTutorialCompleted").GetBoolean().ShouldBeTrue();
+        }
+
+        var user = await GetUserByEmailAsync(email);
+        user.ListenWriteTutorialCompleted.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task MarkListenWriteTutorialCompleted_WhenUnauthenticated_ShouldReturnUnauthorized()
+    {
+        if (!CanRunIntegration())
+        {
+            return;
+        }
+
+        await _fixture.ResetAsync();
+        using var client = _fixture.CreateClient();
+
+        var response = await PostAsJsonWithAllowedOriginAsync(client, "/users/auth/tutorial/listen-write/completed", new { });
+        IsUnauthenticatedStatus(response.StatusCode).ShouldBeTrue();
     }
 
     [Fact]
@@ -689,5 +745,14 @@ public class AuthEndpointsIntegrationTests : IClassFixture<UsersApiIntegrationFi
 
         activities.Count.ShouldBe(1);
         return activities[0];
+    }
+
+    private async Task<ApplicationUser> GetUserByEmailAsync(string email)
+    {
+        _fixture.Factory.ShouldNotBeNull();
+
+        using var scope = _fixture.Factory!.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<UsersDbContext>();
+        return await db.Users.SingleAsync(x => x.Email == email);
     }
 }


### PR DESCRIPTION
## Summary
- persist `listenWriteTutorialCompleted` on the user model and auth endpoints
- add DB migration for the new tutorial-completion flag
- wire webapp auth/session + listen-and-write flow to read/write the tutorial flag
- add/adjust unit and integration tests around the tutorial-completion behavior
- patch vulnerable package resolutions:
  - pin `OpenTelemetry.Api` to `1.15.3`
  - remove legacy `Microsoft.AspNetCore.Identity` `2.3.1` reference from infrastructure project

## Validation
- `dotnet restore` on affected projects (clean)
- `dotnet run` from `src/host/WriteFluency.AppHost` (clean startup, no previous NU1902/NU1903 warnings in that path)
- `dotnet list WriteFluency.sln package --vulnerable --include-transitive` (remaining vulnerability is isolated to `WriteFluency.UsersProgressService.Tests` transitive package)
